### PR TITLE
Make changes DUE-only

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -16,13 +16,15 @@
 #ifdef __has_include
 	#define SW_CAPABLE_PLATFORM __has_include(<SoftwareSerial.h>)
 #else
-	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32F1)
+	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(ARDUINO_ARCH_SAM) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32F1)
 #endif
 
-#define SW_CAPABLE_PLATFORM true
-
 #if SW_CAPABLE_PLATFORM
-	#include "soft_uart.h"
+	#ifdef ARDUINO_ARCH_SAM
+		#include "soft_uart.h"
+	#else
+		#include <SoftwareSerial.h>
+	#endif
 #endif
 
 #include "source/SW_SPI.h"
@@ -966,8 +968,9 @@ class TMC2208Stepper : public TMCStepper {
 		INIT2208_REGISTER(CHOPCONF)		{{.sr=0}};
 		INIT2208_REGISTER(PWMCONF)		{{.sr=0}};
 
-		uint16_t SW_RX = -1;
-		uint16_t SW_TX = -1;
+		#ifdef ARDUINO_ARCH_SAM
+			uint16_t SW_RX = -1, SW_TX = -1;
+		#endif
 
 		struct IFCNT_t 		{ constexpr static uint8_t address = 0x02; };
 		struct OTP_PROG_t 	{ constexpr static uint8_t address = 0x04; };
@@ -979,8 +982,10 @@ class TMC2208Stepper : public TMCStepper {
 		#endif
 
 		Stream * HWSerial = NULL;
-		#if SW_CAPABLE_PLATFORM
+		#ifdef ARDUINO_ARCH_SAM
 			arduino_due::soft_uart::serial<arduino_due::soft_uart::timer_ids::TIMER_TC4, 256, 256> * SWSerial = NULL;
+		#else
+			SoftwareSerial * SWSerial = NULL;
 		#endif
 
 		void write(uint8_t, uint32_t);


### PR DESCRIPTION
If these changes are still relevant, they can be made more acceptable by ensuring they only apply to the DUE platform.

For Marlin Firmware to remain responsive, it will maintain its own fork of TMCStepper, so this might be merged if it patches still-existing software serial issues.